### PR TITLE
Update inventory panel, add item trading details

### DIFF
--- a/description/active/universal/02 Inventory + Rewards.md
+++ b/description/active/universal/02 Inventory + Rewards.md
@@ -1,18 +1,63 @@
-Complete a PBR season and get rewarded!
+**List your items:** */w tpp inventory*  
+Each item in your inventory is assigned an id number for easy usage. 
 
-* Rewards are based on your final rank
-* Reward items are stored in your Inventory
-* Item IDs are listed in your Inventory
+**Use an item:** */w tpp useitem [id number]*
 
-**List your Inventory:** */w tpp inventory*  
-**Use an item:** */w tpp useitem [id]*
+**Get info about an item:** */w tpp checkitem [name or id number]* 
 
-You can also gain rewards through Cheerful Slots!
+## Available items
 
-## Rewards
+* **Crates**: contain badges, tokens, any of these other items, or nothing at all
+* **Noise Maker**: play the cry of your currently selected badge
+* **Mail**: post a message on screen
+* **Emote Rain**: make it rain emotes on screen
+* **Chatter**: play text-to-speech of a random message from chat
+* *And more!*
 
-* **Crates**: contain badges, tokens, any of these other items, or nothing at all!
-* **Noise Maker**: play the cry of the badge you're wearing
-* **Mail**: post a message to the stream
-* **Emote Rain**: make it rain emotes
-* **Chatter**: allows people to text-to-speech on stream a random message from chat
+**Buy/sell items** with: *buyitem, listbuyitem, cancelbuyitem, sellitem, listsellitem, cancelsellitem.*
+
+## Earn rewards
+
+Rewards include both tokens and items!
+
+* Earn exp and rewards at the end of each PBR season, based on your leaderboard rank
+* Earn rewards from exp levelups (and earn exp from inputting in runs and betting in matches)
+* Randomly earn rewards through Cheerful Slots
+
+## Buying items
+
+*/w tpp buyitem 1 emoterain t5* (buy 1 emoterain for 5 tokens or less)
+
+*/w tpp buyitem 2 emoterain t5* (buy 2 emoterains for 5 tokens or less each)
+
+Some items only buy/sell in packs:
+
+*/w tpp buyitem 1 5pack noisemaker t5* (buy 1 5-pack of noisemakers for 5 tokens or less)
+
+If the item you want isn't currently sold at the desired price, you can place a buy offer for it:
+
+*/w tpp buyitem 1 emoterain t5 7d* (place a buy offer for 1 emoterain at 5 tokens or less; this offer expires in 7 days)
+
+*/w tpp listbuyitem* (list all your offers to buy items)
+
+*/w tpp cancelbuyitem emoterain* (cancel all your buy offers for emote rains)
+
+## Selling items
+
+To sell an item, use its id number from your inventory, prefixed by a #.
+
+*/w tpp sellitem 1 #3 t5* (sell 1 of your 3rd item for 5 tokens)
+
+*/w tpp sellitem 2 #3 t5* (sell 2 of your 3rd item for 5 tokens each)
+
+Some items only buy/sell in packs:
+
+*/w tpp sellitem 1 5pack #2 t5* (sell 1 5-pack of your 2nd item for 5 tokens)
+
+If the item you want isn't currently bought at the desired price, you can place a sell offer for it:
+
+*/w tpp sellitem 1 #2 t5 7d* (place a sell offer for 1 of your 2nd item for 5 tokens; this offer expires in 7 days)
+
+*/w tpp listsellitem* (list all your offers to sell items)
+
+*/w tpp cancelsellitem #1* (cancel all your sell offers of your 1st item)

--- a/description/active/universal/02 Inventory + Rewards.md
+++ b/description/active/universal/02 Inventory + Rewards.md
@@ -14,6 +14,8 @@ Each item in your inventory is assigned an id number for easy usage.
 * **Chatter**: play text-to-speech of a random message from chat
 * *And more!*
 
+To learn about item trading, see the **ITEM TRADING** panel.
+
 **Buy/sell items** with: *buyitem, listbuyitem, cancelbuyitem, sellitem, listsellitem, cancelsellitem.*
 
 ## Earn rewards

--- a/description/active/universal/04 Badges.md
+++ b/description/active/universal/04 Badges.md
@@ -12,3 +12,5 @@ Manage badges with the TPP Bot!
 **See a badge's circulation:** */w tpp checkbadge [badge]*  
 **Check your Pokédex:** */w tpp pokedex*  
 **Check another player's Pokédex:** */w tpp pokedex [username]*
+
+To learn about badge trading, see the **BADGE TRADING** panel.

--- a/description/active/universal/05 Badge Trading.md
+++ b/description/active/universal/05 Badge Trading.md
@@ -8,26 +8,26 @@ For example:
 
 #### Buying Pokémon badges
 
-*/w tpp buybadge pikachu* to see the price of Pikachu badges being sold (if any).
+*/w tpp buybadge pikachu* (see the price of Pikachu badges being sold, if any)
 
-*/w tpp buybadge 1 pikachu t5* to purchase one Pikachu badge for T5 tokens or less.
+*/w tpp buybadge 1 pikachu t5* (buy 1 Pikachu badge for 5 tokens or less)
 
-*/w tpp buybadge 2 pikachu t5* to purchase two Pikachu badges for T5 tokens or less each.
+*/w tpp buybadge 2 pikachu t5* (buy 2 Pikachu badges for 5 tokens or less each)
 
-*/w tpp buybadge 1 pikachu t5 7d* to place a buy offer for one Pikachu badge at T5 tokens or less, the offer expires in 7 days
+*/w tpp buybadge 1 pikachu t5 7d* (place a buy offer for 1 Pikachu badge at 5 tokens or less; the offer expires in 7 days)
 
-*/w tpp listbuybadge* to list all your offers to buy Pokémon badges.
+*/w tpp listbuybadge* (list all your offers to buy Pokémon badges)
 
-*/w tpp cancelbuybadge pikachu* to cancel all your buy offers for Pikachu.
+*/w tpp cancelbuybadge pikachu* (cancel all your buy offers for Pikachu)
 
 #### Selling Pokémon badges
 
-*/w tpp sellbadge pikachu* to see buy offers for Pikachu badges.
+*/w tpp sellbadge pikachu* (see buy offers for Pikachu badges)
 
-*/w tpp sellbadge 1 pikachu t5* to sell your Pikachu badge for T5 tokens.
+*/w tpp sellbadge 1 pikachu t5* (sell 1 Pikachu badge for 5 tokens)
 
-*/w tpp sellbadge 2 pikachu t5* to sell two of your Pikachu badge for T5 tokens each.
+*/w tpp sellbadge 2 pikachu t5* (sell 2 of your Pikachu badges for 5 tokens each)
 
-*/w tpp listsellbadge* to list all your offers to sell Pokémon badges.
+*/w tpp listsellbadge* (list all your offers to sell Pokémon badges)
 
-*/w tpp cancelsellbadge pikachu* to stop selling all of your Pikachu badges.
+*/w tpp cancelsellbadge pikachu* (stop selling all of your Pikachu badges)


### PR DESCRIPTION
With this change, all items info (including item trading) will be under the `Inventory & Rewards` panel.  This is in contrast to badges which has a `Badges` panel and a `Badge Trading` panel.  

Do we really want badges to have separate panels?  I feel like one panel is enough.  If we keep separate panels, imo we should add a note in the `Badges` panel about there being a separate panel for badge trading (or people may assume trading info isn't in the description when they don't see it under `Badges`).

Issue #11 