### PR TITLE
Fix subscription token amounts

### DIFF
--- a/description/active/universal/10 Support TPP.md
+++ b/description/active/universal/10 Support TPP.md
@@ -4,11 +4,13 @@ Subscriptions pay for the great hardware that allows TPP to be a 1080p60 stream,
 
 ###[**Click here to subscribe!**](https://secure.twitch.tv/products/twitchplayspokemon)
 
-The longer you sub, the better the rewards!  With every Loyalty League advanced, you receive 10 tokens plus the number of your league.  Reach a maximum of League 15 and get 25 tokens per month!
+The longer you sub, the better the rewards!  With every Loyalty League advanced, you receive 2 * (5 + the number of your league) tokens.
 
 Tier 1: **$4.99**/mo & **Twitch Prime** - *+1 league per month*  
 Tier 2: **$9.99**/mo - *+2 leagues per month*  
 Tier 3: **$24.99**/mo - *+5 leagues per month*  
+
+Reach the maximum of League 15 and you'll receive 40, 80, or 200 tokens each month! (Tiers 1, 2, or 3 respectively)
 
 Check your league at any time by typing: */w tpp league*
 


### PR DESCRIPTION
These amounts became incorrect when all token drops were doubled.
Also mention the max payouts for each tier, instead of just for tier 1.